### PR TITLE
Fixes misaligned collapsed comments

### DIFF
--- a/hackernews-userstyles.css
+++ b/hackernews-userstyles.css
@@ -1,7 +1,7 @@
 @-moz-document url-prefix("https://news.ycombinator.com/") {
 /* reset */
 body, td, table, input, textarea, .pagetop, * {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif; 
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
   font-weight: 400;
   -webkit-font-smoothing: antialiased;
 }
@@ -167,7 +167,6 @@ table {
   font-size: 12px;
   color: #555;
   position: absolute;
-  top: 16px;
   left: 0;
 }
 
@@ -241,4 +240,13 @@ table {
   color: #F06D3C;
   display: inline-block;
 }
+
+td.ind {
+  width: 0px;
+}
+
+td.votelinks {
+  width: 0px;
+}
+
 }


### PR DESCRIPTION
I noticed when collapsing comments that the title would not remain in place. This seems to resolve that, however I apologize if this is hacky or otherwise improper, I don't know css very well.

p.s. I opened this pull request in addition to the other one in case you only wanted to merge this one.